### PR TITLE
Add several features for Kagami.

### DIFF
--- a/_includes/gitalk.html
+++ b/_includes/gitalk.html
@@ -1,0 +1,18 @@
+<div id="gitalk-container"></div>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.css">
+<script src="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
+<script>
+    var gitalk = new Gitalk({
+        id: '{{ page.title }}',
+        clientID: '{{ site.gitalk.id }}',
+        clientSecret: '{{ site.gitalk.secret }}',
+        repo: '{{ site.gitalk.repository }}',
+        owner: '{{ site.github_username }}',
+        admin: ['{{ site.github_username }}'],
+        body: location.href,
+        proxy: '{{ site.gitalk.proxy | default: "https://cors-anywhere.azm.workers.dev/https://github.com/login/oauth/access_token" }}',
+        language: '{{ site.lang | default: "en" }}',
+        distractionFreeMode: false
+    })
+    gitalk.render('gitalk-container')
+</script>

--- a/_includes/mermaid.html
+++ b/_includes/mermaid.html
@@ -1,0 +1,14 @@
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+<script type="text/javascript">
+  (function () {
+    mermaid.init({ startOnLoad: true }, "pre code.language-mermaid", function () {
+      const codeBlock = document.querySelector('code.language-mermaid');
+      codeBlock.style.backgroundColor = 'initial';
+
+      const preBlock = codeBlock.parentNode;
+      preBlock.style.border = 'none';
+      preBlock.style.textAlign = 'center';
+      preBlock.style.backgroundColor = 'initial';
+    });
+  })();
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,7 @@ layout: blank
       {{ content }}
     </div>
     {% include retina-image.html %}
+    {% include mermaid.html %}
   </main>
 
   {% include footer.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,7 +25,12 @@ layout: default
     {% endif %}
   </footer>
 
-  {% if jekyll.environment == 'production' and site.disqus_shortname and page.comments != false %}
+  {% if jekyll.environment == 'production' and page.comments != false %}
+  {% if site.disqus_shortname %}
   {% include disqus.html %}
+  {% elsif site.gitalk %}
   {% endif %}
+  {% include gitalk.html %}
+  {% endif %}
+
 </article>


### PR DESCRIPTION
## Add Gitalk Support

[Gitalk](https://github.com/gitalk/gitalk) can be used when enable comment system and add configurations in config.yml.

```
gitalk:
  id: <GitHub Application Client ID>
  secret: <GitHub Application Client Secret>
  repository: <GitHub Repository>
  proxy: <GitHub oauth request reverse proxy for CORS>
```

## Add Mermaid Diagram Generator Support

[Mermaid](https://mermaid-js.github.io/mermaid/#/) can be used in markdown code block now.

> Not yet support macOS Safari because `svg` in `code` cannot be displayed.